### PR TITLE
[BACKPORT] PS-4561: Disabled product options are not removed from Yves > PDP

### DIFF
--- a/src/Spryker/Shared/ProductOption/Transfer/product_option.transfer.xml
+++ b/src/Spryker/Shared/ProductOption/Transfer/product_option.transfer.xml
@@ -159,4 +159,10 @@
         <property name="foreignKeys" type="array"/>
     </transfer>
 
+    <transfer name="ProductAbstractOptionGroupStatus">
+        <property name="idProductAbstract" type="int" />
+        <property name="isActive" type="bool" />
+        <property name="productOptionGroupName" type="string" />
+    </transfer>
+
 </transfers>

--- a/src/Spryker/Zed/ProductOption/Business/ProductOptionBusinessFactory.php
+++ b/src/Spryker/Zed/ProductOption/Business/ProductOptionBusinessFactory.php
@@ -28,6 +28,7 @@ use Spryker\Zed\ProductOption\ProductOptionDependencyProvider;
 /**
  * @method \Spryker\Zed\ProductOption\ProductOptionConfig getConfig()
  * @method \Spryker\Zed\ProductOption\Persistence\ProductOptionQueryContainerInterface getQueryContainer()
+ * @method \Spryker\Zed\ProductOption\Persistence\ProductOptionRepositoryInterface getRepository()
  */
 class ProductOptionBusinessFactory extends AbstractBusinessFactory
 {

--- a/src/Spryker/Zed/ProductOption/Business/ProductOptionFacade.php
+++ b/src/Spryker/Zed/ProductOption/Business/ProductOptionFacade.php
@@ -21,6 +21,7 @@ use Spryker\Zed\Kernel\Business\AbstractFacade;
 
 /**
  * @method \Spryker\Zed\ProductOption\Business\ProductOptionBusinessFactory getFactory()
+ * @method \Spryker\Zed\ProductOption\Persistence\ProductOptionRepositoryInterface getRepository()
  */
 class ProductOptionFacade extends AbstractFacade implements ProductOptionFacadeInterface
 {
@@ -316,5 +317,20 @@ class ProductOptionFacade extends AbstractFacade implements ProductOptionFacadeI
         return $this->getFactory()
             ->createProductOptionGroupReader()
             ->checkProductOptionGroupExistenceByProductOptionValueId($idProductOptionValue);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @api
+     *
+     * @param int[] $productAbstractIds
+     *
+     * @return \Generated\Shared\Transfer\ProductAbstractOptionGroupStatusTransfer[]
+     */
+    public function getProductAbstractOptionGroupStatusesByProductAbstractIds(array $productAbstractIds): array
+    {
+        return $this->getRepository()
+            ->getProductAbstractOptionGroupStatusesByProductAbstractIds($productAbstractIds);
     }
 }

--- a/src/Spryker/Zed/ProductOption/Business/ProductOptionFacadeInterface.php
+++ b/src/Spryker/Zed/ProductOption/Business/ProductOptionFacadeInterface.php
@@ -279,4 +279,17 @@ interface ProductOptionFacadeInterface
      * @return bool
      */
     public function checkProductOptionGroupExistenceByProductOptionValueId(int $idProductOptionValue): bool;
+
+    /**
+     * Specification:
+     * - Retrieves product option group name and status for all abstract products by provided IDs.
+     * - Returns ProductAbstractOptionGroupStatusTransfer[] array with 'idProductAbstract', 'isActive' and 'productOptionGroupName' values.
+     *
+     * @api
+     *
+     * @param int[] $productAbstractIds
+     *
+     * @return \Generated\Shared\Transfer\ProductAbstractOptionGroupStatusTransfer[]
+     */
+    public function getProductAbstractOptionGroupStatusesByProductAbstractIds(array $productAbstractIds): array;
 }

--- a/src/Spryker/Zed/ProductOption/Persistence/ProductOptionPersistenceFactory.php
+++ b/src/Spryker/Zed/ProductOption/Persistence/ProductOptionPersistenceFactory.php
@@ -13,11 +13,13 @@ use Orm\Zed\ProductOption\Persistence\SpyProductOptionGroupQuery;
 use Orm\Zed\ProductOption\Persistence\SpyProductOptionValuePriceQuery;
 use Orm\Zed\ProductOption\Persistence\SpyProductOptionValueQuery;
 use Spryker\Zed\Kernel\Persistence\AbstractPersistenceFactory;
+use Spryker\Zed\ProductOption\Persistence\Propel\Mapper\ProductOptionMapper;
 use Spryker\Zed\ProductOption\ProductOptionDependencyProvider;
 
 /**
  * @method \Spryker\Zed\ProductOption\ProductOptionConfig getConfig()
  * @method \Spryker\Zed\ProductOption\Persistence\ProductOptionQueryContainerInterface getQueryContainer()
+ * @method \Spryker\Zed\ProductOption\Persistence\ProductOptionRepositoryInterface getRepository()
  */
 class ProductOptionPersistenceFactory extends AbstractPersistenceFactory
 {
@@ -59,6 +61,14 @@ class ProductOptionPersistenceFactory extends AbstractPersistenceFactory
     public function createProductAbstractProductOptionGroupQuery()
     {
         return SpyProductAbstractProductOptionGroupQuery::create();
+    }
+
+    /**
+     * @return \Spryker\Zed\ProductOption\Persistence\Propel\Mapper\ProductOptionMapper
+     */
+    public function createProductOptionMapper(): ProductOptionMapper
+    {
+        return new ProductOptionMapper();
     }
 
     /**

--- a/src/Spryker/Zed/ProductOption/Persistence/ProductOptionRepository.php
+++ b/src/Spryker/Zed/ProductOption/Persistence/ProductOptionRepository.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\ProductOption\Persistence;
+
+use Generated\Shared\Transfer\ProductAbstractOptionGroupStatusTransfer;
+use Orm\Zed\ProductOption\Persistence\Map\SpyProductAbstractProductOptionGroupTableMap;
+use Orm\Zed\ProductOption\Persistence\Map\SpyProductOptionGroupTableMap;
+use Spryker\Zed\Kernel\Persistence\AbstractRepository;
+
+/**
+ * @method \Spryker\Zed\ProductOption\Persistence\ProductOptionPersistenceFactory getFactory()
+ */
+class ProductOptionRepository extends AbstractRepository implements ProductOptionRepositoryInterface
+{
+    /**
+     * @param int[] $productAbstractIds
+     *
+     * @return \Generated\Shared\Transfer\ProductAbstractOptionGroupStatusTransfer[]
+     */
+    public function getProductAbstractOptionGroupStatusesByProductAbstractIds(array $productAbstractIds): array
+    {
+        $productAbstractOptionGroupStatuses = $this->getFactory()
+            ->createProductAbstractProductOptionGroupQuery()
+            ->filterByFkProductAbstract_In($productAbstractIds)
+            ->joinSpyProductOptionGroup()
+            ->select([
+                ProductAbstractOptionGroupStatusTransfer::ID_PRODUCT_ABSTRACT,
+                ProductAbstractOptionGroupStatusTransfer::IS_ACTIVE,
+                ProductAbstractOptionGroupStatusTransfer::PRODUCT_OPTION_GROUP_NAME,
+            ])
+            ->withColumn(SpyProductAbstractProductOptionGroupTableMap::COL_FK_PRODUCT_ABSTRACT, ProductAbstractOptionGroupStatusTransfer::ID_PRODUCT_ABSTRACT)
+            ->withColumn(SpyProductOptionGroupTableMap::COL_ACTIVE, ProductAbstractOptionGroupStatusTransfer::IS_ACTIVE)
+            ->withColumn(SpyProductOptionGroupTableMap::COL_NAME, ProductAbstractOptionGroupStatusTransfer::PRODUCT_OPTION_GROUP_NAME)
+            ->find()
+            ->toArray();
+
+        return $this->getFactory()
+            ->createProductOptionMapper()
+            ->mapProductAbstractOptionGroupStatusesToTransfers($productAbstractOptionGroupStatuses);
+    }
+}

--- a/src/Spryker/Zed/ProductOption/Persistence/ProductOptionRepositoryInterface.php
+++ b/src/Spryker/Zed/ProductOption/Persistence/ProductOptionRepositoryInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\ProductOption\Persistence;
+
+interface ProductOptionRepositoryInterface
+{
+    /**
+     * @param int[] $productAbstractIds
+     *
+     * @return \Generated\Shared\Transfer\ProductAbstractOptionGroupStatusTransfer[]
+     */
+    public function getProductAbstractOptionGroupStatusesByProductAbstractIds(array $productAbstractIds): array;
+}

--- a/src/Spryker/Zed/ProductOption/Persistence/Propel/Mapper/ProductOptionMapper.php
+++ b/src/Spryker/Zed/ProductOption/Persistence/Propel/Mapper/ProductOptionMapper.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\ProductOption\Persistence\Propel\Mapper;
+
+use Generated\Shared\Transfer\ProductAbstractOptionGroupStatusTransfer;
+
+class ProductOptionMapper
+{
+    /**
+     * @param array $productAbstractOptionGroupStatuses
+     *
+     * @return array
+     */
+    public function mapProductAbstractOptionGroupStatusesToTransfers(
+        array $productAbstractOptionGroupStatuses
+    ): array {
+        $productAbstractOptionGroupStatusTransfers = [];
+        foreach ($productAbstractOptionGroupStatuses as $productAbstractOptionGroupStatus) {
+            $productAbstractOptionGroupStatusTransfers[] = $this->mapProductAbstractOptionGroupStatusToTransfer(
+                $productAbstractOptionGroupStatus
+            );
+        }
+
+        return $productAbstractOptionGroupStatusTransfers;
+    }
+
+    /**
+     * @param array $productAbstractOptionGroupStatus
+     *
+     * @return \Generated\Shared\Transfer\ProductAbstractOptionGroupStatusTransfer
+     */
+    protected function mapProductAbstractOptionGroupStatusToTransfer(
+        array $productAbstractOptionGroupStatus
+    ): ProductAbstractOptionGroupStatusTransfer {
+        return (new ProductAbstractOptionGroupStatusTransfer())
+            ->fromArray($productAbstractOptionGroupStatus);
+    }
+}


### PR DESCRIPTION
- Developer(s): @vitaliykirichenkoit

- Ticket: https://spryker.atlassian.net/browse/PS-4561

- Academy PR: ACADEMY_URL_HERE

-----------------------------------------
- Suite PR: https://github.com/spryker/suite-nonsplit/pull/698
- Core PR: https://github.com/spryker/spryker/pull/3828

- Backport PR (ProductOption): https://github.com/spryker/product-option/pull/1
-----------------------------------------

- Release Group: https://release.spryker.com/release-groups/view/685

- Release Overview: https://release.spryker.com/core/PS-4561 [Replace with actual PR overview link]

#### Please confirm

- [x] No new OS components - or they have been approved by legal department

#### Documentation

- [x] Functional documentation provided or in progress?
- [x] Integration guide for projects provided or not needed?
- [x] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   ProductOption         | minor                 |                       |

#### Release Notes

- Provided functionality to check Product Option Group statuses for specified abstract products.

-----------------------------------------

#### Module ProductOption

##### Change log

Improvements

- Introduced `ProductOptionFacade::getProductAbstractOptionGroupStatusesByProductAbstractIds()`.
