### PR TITLE
PS-9715: Product option - if price for currency not exist, price of another currency is used.

### DIFF
--- a/src/Spryker/Zed/ProductOption/Business/OptionGroup/ProductOptionValuePriceReader.php
+++ b/src/Spryker/Zed/ProductOption/Business/OptionGroup/ProductOptionValuePriceReader.php
@@ -73,14 +73,15 @@ class ProductOptionValuePriceReader implements ProductOptionValuePriceReaderInte
 
     /**
      * @param \Orm\Zed\ProductOption\Persistence\SpyProductOptionValue $productOptionValueEntity
+     * @param string|null $currencyCode
      *
      * @return int|null
      */
-    public function getCurrentGrossPrice(SpyProductOptionValue $productOptionValueEntity)
+    public function getCurrentGrossPrice(SpyProductOptionValue $productOptionValueEntity, ?string $currencyCode = null)
     {
         $priceMap = $this->getCurrencyFilteredPriceMap(
             $productOptionValueEntity->getProductOptionValuePrices(),
-            $this->getCurrentIdCurrency()
+            $this->getCurrentIdCurrency($currencyCode)
         );
 
         $currentIdStore = $this->storeFacade->getCurrentStore()->getIdStore();
@@ -97,14 +98,15 @@ class ProductOptionValuePriceReader implements ProductOptionValuePriceReaderInte
 
     /**
      * @param \Orm\Zed\ProductOption\Persistence\SpyProductOptionValue $productOptionValueEntity
+     * @param string|null $currencyCode
      *
      * @return int|null
      */
-    public function getCurrentNetPrice(SpyProductOptionValue $productOptionValueEntity)
+    public function getCurrentNetPrice(SpyProductOptionValue $productOptionValueEntity, ?string $currencyCode = null)
     {
         $priceMap = $this->getCurrencyFilteredPriceMap(
             $productOptionValueEntity->getProductOptionValuePrices(),
-            $this->getCurrentIdCurrency()
+            $this->getCurrentIdCurrency($currencyCode)
         );
 
         $currentIdStore = $this->storeFacade->getCurrentStore()->getIdStore();
@@ -140,13 +142,13 @@ class ProductOptionValuePriceReader implements ProductOptionValuePriceReaderInte
     }
 
     /**
+     * @param string|null $currencyCode
+     *
      * @return int
      */
-    protected function getCurrentIdCurrency()
+    protected function getCurrentIdCurrency(?string $currencyCode = null)
     {
-        $currency = $this->currencyFacade->getCurrent();
-
-        return $this->currencyFacade->fromIsoCode($currency->getCode())->getIdCurrency();
+        return $this->currencyFacade->fromIsoCode($currencyCode ?? $this->currencyFacade->getCurrent()->getCode())->getIdCurrency();
     }
 
     /**

--- a/src/Spryker/Zed/ProductOption/Business/OptionGroup/ProductOptionValuePriceReaderInterface.php
+++ b/src/Spryker/Zed/ProductOption/Business/OptionGroup/ProductOptionValuePriceReaderInterface.php
@@ -14,17 +14,19 @@ interface ProductOptionValuePriceReaderInterface
 {
     /**
      * @param \Orm\Zed\ProductOption\Persistence\SpyProductOptionValue $productOptionValueEntity
+     * @param string|null $currencyCode
      *
      * @return int|null
      */
-    public function getCurrentGrossPrice(SpyProductOptionValue $productOptionValueEntity);
+    public function getCurrentGrossPrice(SpyProductOptionValue $productOptionValueEntity, ?string $currencyCode = null);
 
     /**
      * @param \Orm\Zed\ProductOption\Persistence\SpyProductOptionValue $productOptionValueEntity
+     * @param string|null $currencyCode
      *
      * @return int|null
      */
-    public function getCurrentNetPrice(SpyProductOptionValue $productOptionValueEntity);
+    public function getCurrentNetPrice(SpyProductOptionValue $productOptionValueEntity, ?string $currencyCode = null);
 
     /**
      * @param \Generated\Shared\Transfer\ProductOptionValueStorePricesRequestTransfer $storePricesRequestTransfer

--- a/src/Spryker/Zed/ProductOption/Business/OptionGroup/ProductOptionValueReader.php
+++ b/src/Spryker/Zed/ProductOption/Business/OptionGroup/ProductOptionValueReader.php
@@ -38,17 +38,18 @@ class ProductOptionValueReader implements ProductOptionValueReaderInterface
 
     /**
      * @param int $idProductOptionValue
+     * @param string|null $currencyCode
      *
      * @throws \Spryker\Zed\ProductOption\Business\Exception\ProductOptionNotFoundException
      *
      * @return \Generated\Shared\Transfer\ProductOptionTransfer
      */
-    public function getProductOption($idProductOptionValue)
+    public function getProductOption($idProductOptionValue, ?string $currencyCode = null)
     {
         $productOptionValueEntity = $this->findOptionValueById((int)$idProductOptionValue);
 
         if ($productOptionValueEntity) {
-            return $this->hydrateProductOptionTransfer($productOptionValueEntity);
+            return $this->hydrateProductOptionTransfer($productOptionValueEntity, $currencyCode);
         }
 
         throw new ProductOptionNotFoundException(
@@ -103,16 +104,17 @@ class ProductOptionValueReader implements ProductOptionValueReaderInterface
 
     /**
      * @param \Orm\Zed\ProductOption\Persistence\SpyProductOptionValue $productOptionValueEntity
+     * @param string|null $currencyCode
      *
      * @return \Generated\Shared\Transfer\ProductOptionTransfer
      */
-    protected function hydrateProductOptionTransfer(SpyProductOptionValue $productOptionValueEntity)
+    protected function hydrateProductOptionTransfer(SpyProductOptionValue $productOptionValueEntity, ?string $currencyCode = null)
     {
         $productOptionTransfer = new ProductOptionTransfer();
         $productOptionTransfer->fromArray($productOptionValueEntity->toArray(), true);
         $productOptionTransfer->setGroupName($productOptionValueEntity->getSpyProductOptionGroup()->getName());
-        $productOptionTransfer->setUnitGrossPrice($this->productOptionValuePriceReader->getCurrentGrossPrice($productOptionValueEntity));
-        $productOptionTransfer->setUnitNetPrice($this->productOptionValuePriceReader->getCurrentNetPrice($productOptionValueEntity));
+        $productOptionTransfer->setUnitGrossPrice($this->productOptionValuePriceReader->getCurrentGrossPrice($productOptionValueEntity, $currencyCode));
+        $productOptionTransfer->setUnitNetPrice($this->productOptionValuePriceReader->getCurrentNetPrice($productOptionValueEntity, $currencyCode));
 
         return $productOptionTransfer;
     }

--- a/src/Spryker/Zed/ProductOption/Business/OptionGroup/ProductOptionValueReaderInterface.php
+++ b/src/Spryker/Zed/ProductOption/Business/OptionGroup/ProductOptionValueReaderInterface.php
@@ -29,12 +29,13 @@ interface ProductOptionValueReaderInterface
 
     /**
      * @param int $idProductOptionValue
+     * @param string|null $currencyCode
      *
      * @throws \Spryker\Zed\ProductOption\Business\Exception\ProductOptionNotFoundException
      *
      * @return \Generated\Shared\Transfer\ProductOptionTransfer
      */
-    public function getProductOption($idProductOptionValue);
+    public function getProductOption($idProductOptionValue, ?string $currencyCode = null);
 
     /**
      * @param \Generated\Shared\Transfer\ProductOptionCriteriaTransfer $productOptionCriteriaTransfer

--- a/src/Spryker/Zed/ProductOption/Business/ProductOptionFacade.php
+++ b/src/Spryker/Zed/ProductOption/Business/ProductOptionFacade.php
@@ -80,14 +80,15 @@ class ProductOptionFacade extends AbstractFacade implements ProductOptionFacadeI
      * @api
      *
      * @param int $idProductOptionValue
+     * @param string|null $currencyCode
      *
      * @return \Generated\Shared\Transfer\ProductOptionTransfer
      */
-    public function getProductOptionValueById($idProductOptionValue)
+    public function getProductOptionValueById($idProductOptionValue, ?string $currencyCode = null)
     {
         return $this->getFactory()
             ->createProductOptionValueReader()
-            ->getProductOption($idProductOptionValue);
+            ->getProductOption($idProductOptionValue, $currencyCode);
     }
 
     /**

--- a/src/Spryker/Zed/ProductOption/Business/ProductOptionFacadeInterface.php
+++ b/src/Spryker/Zed/ProductOption/Business/ProductOptionFacadeInterface.php
@@ -82,15 +82,17 @@ interface ProductOptionFacadeInterface
      * Specification:
      * - Reads product option from persistence.
      * - Net and gross unit prices are calculated using current store, and current currency.
+     * - If currency code not provided it will use default store currency.
      * - Uses default store (fkStore = NULL) prices when the option has no currency definition for the current store.
      *
      * @api
      *
      * @param int $idProductOptionValue
+     * @param string|null $currencyCode
      *
      * @return \Generated\Shared\Transfer\ProductOptionTransfer
      */
-    public function getProductOptionValueById($idProductOptionValue);
+    public function getProductOptionValueById($idProductOptionValue, ?string $currencyCode = null);
 
     /**
      * Specification:


### PR DESCRIPTION
Branch: backport/ps-9715/product-option-6.10.0
Ticket: https://spryker.atlassian.net/browse/PS-9715
Target Version: 6.10.0

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   ProductOption               | minor                 |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module ProductOption

##### Change log

Improvements

- Adjusted `ProductOptionFacade::getProductOptionValueById()` with optional parameter `$currencyCode`.
