### PR TITLE
GLUE-10992: Added ProductOptionFacade::get() and related classes

### DIFF
--- a/src/Spryker/Client/ProductOption/Dependency/Client/ProductOptionToCurrencyClientInterface.php
+++ b/src/Spryker/Client/ProductOption/Dependency/Client/ProductOptionToCurrencyClientInterface.php
@@ -4,6 +4,7 @@
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
 namespace Spryker\Client\ProductOption\Dependency\Client;
 
 interface ProductOptionToCurrencyClientInterface

--- a/src/Spryker/Client/ProductOption/Dependency/Client/ProductOptionToPriceClientInterface.php
+++ b/src/Spryker/Client/ProductOption/Dependency/Client/ProductOptionToPriceClientInterface.php
@@ -4,6 +4,7 @@
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
 namespace Spryker\Client\ProductOption\Dependency\Client;
 
 interface ProductOptionToPriceClientInterface

--- a/src/Spryker/Client/ProductOption/Dependency/Client/ProductOptionToStorageClientInterface.php
+++ b/src/Spryker/Client/ProductOption/Dependency/Client/ProductOptionToStorageClientInterface.php
@@ -4,6 +4,7 @@
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
 namespace Spryker\Client\ProductOption\Dependency\Client;
 
 interface ProductOptionToStorageClientInterface

--- a/src/Spryker/Client/ProductOption/ProductOptionClient.php
+++ b/src/Spryker/Client/ProductOption/ProductOptionClient.php
@@ -15,7 +15,7 @@ use Spryker\Client\Kernel\AbstractClient;
 class ProductOptionClient extends AbstractClient implements ProductOptionClientInterface
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *

--- a/src/Spryker/Client/ProductOption/ProductOptionClientInterface.php
+++ b/src/Spryker/Client/ProductOption/ProductOptionClientInterface.php
@@ -4,6 +4,7 @@
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
 namespace Spryker\Client\ProductOption;
 
 /**

--- a/src/Spryker/Client/ProductOption/Storage/ProductOptionStorageInterface.php
+++ b/src/Spryker/Client/ProductOption/Storage/ProductOptionStorageInterface.php
@@ -4,6 +4,7 @@
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
 namespace Spryker\Client\ProductOption\Storage;
 
 interface ProductOptionStorageInterface

--- a/src/Spryker/Shared/ProductOption/Transfer/product_option.transfer.xml
+++ b/src/Spryker/Shared/ProductOption/Transfer/product_option.transfer.xml
@@ -25,11 +25,13 @@
     </transfer>
 
     <transfer name="ProductOptionCriteria">
-        <property name="ProductOptionIds" type="array" />
-        <property name="productOptionGroupIsActive" type="bool" />
-        <property name="productConcreteSku" type="string" />
+        <property name="productOptionIds" type="array" singular="productOptionIds"/>
+        <property name="productOptionSkus" type="string[]" singular="productOptionSku"/>
+        <property name="productOptionGroupIsActive" type="bool"/>
+        <property name="productConcreteSku" type="string"/>
         <property name="priceMode" type="string"/>
         <property name="currencyIsoCode" type="string"/>
+        <property name="storeIds" type="array" singular="storeId"/>
     </transfer>
 
     <transfer name="Item">
@@ -84,6 +86,7 @@
         <property name="prices" type="MoneyValue[]" singular="price" />
         <property name="sku" type="string" />
         <property name="fkProductOptionGroup" type="int" />
+        <property name="productOptionGroup" type="ProductOptionGroup"/>
         <property name="value" type="string" />
         <property name="optionHash" type="string" />
     </transfer>

--- a/src/Spryker/Zed/ProductOption/Business/OptionGroup/AbstractProductOptionSaverInterface.php
+++ b/src/Spryker/Zed/ProductOption/Business/OptionGroup/AbstractProductOptionSaverInterface.php
@@ -4,6 +4,7 @@
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
 namespace Spryker\Zed\ProductOption\Business\OptionGroup;
 
 use Generated\Shared\Transfer\ProductOptionGroupTransfer;

--- a/src/Spryker/Zed/ProductOption/Business/OptionGroup/ProductOptionGroupReaderInterface.php
+++ b/src/Spryker/Zed/ProductOption/Business/OptionGroup/ProductOptionGroupReaderInterface.php
@@ -4,6 +4,7 @@
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
 namespace Spryker\Zed\ProductOption\Business\OptionGroup;
 
 interface ProductOptionGroupReaderInterface

--- a/src/Spryker/Zed/ProductOption/Business/OptionGroup/ProductOptionGroupSaver.php
+++ b/src/Spryker/Zed/ProductOption/Business/OptionGroup/ProductOptionGroupSaver.php
@@ -149,9 +149,10 @@ class ProductOptionGroupSaver implements ProductOptionGroupSaverInterface
         ProductOptionGroupTransfer $productOptionGroupTransfer,
         SpyProductOptionGroup $productOptionGroupEntity
     ) {
-
-        if ($productOptionGroupTransfer->getName() &&
-            strpos($productOptionGroupTransfer->getName(), ProductOptionConfig::PRODUCT_OPTION_GROUP_NAME_TRANSLATION_PREFIX) === false) {
+        if (
+            $productOptionGroupTransfer->getName() &&
+            strpos($productOptionGroupTransfer->getName(), ProductOptionConfig::PRODUCT_OPTION_GROUP_NAME_TRANSLATION_PREFIX) === false
+        ) {
             $productOptionGroupTransfer->setName(
                 ProductOptionConfig::PRODUCT_OPTION_GROUP_NAME_TRANSLATION_PREFIX . $productOptionGroupTransfer->getName()
             );

--- a/src/Spryker/Zed/ProductOption/Business/OptionGroup/ProductOptionGroupSaverInterface.php
+++ b/src/Spryker/Zed/ProductOption/Business/OptionGroup/ProductOptionGroupSaverInterface.php
@@ -4,6 +4,7 @@
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
 namespace Spryker\Zed\ProductOption\Business\OptionGroup;
 
 use Generated\Shared\Transfer\ProductOptionGroupTransfer;

--- a/src/Spryker/Zed/ProductOption/Business/OptionGroup/ProductOptionValuePriceReader.php
+++ b/src/Spryker/Zed/ProductOption/Business/OptionGroup/ProductOptionValuePriceReader.php
@@ -136,6 +136,7 @@ class ProductOptionValuePriceReader implements ProductOptionValuePriceReaderInte
         if ($priceMode === $this->getGrossPriceModeIdentifier()) {
             return $productOptionTransfer->getUnitGrossPrice();
         }
+
         return $productOptionTransfer->getUnitNetPrice();
     }
 

--- a/src/Spryker/Zed/ProductOption/Business/OptionGroup/ProductOptionValuePriceSaver.php
+++ b/src/Spryker/Zed/ProductOption/Business/OptionGroup/ProductOptionValuePriceSaver.php
@@ -41,6 +41,7 @@ class ProductOptionValuePriceSaver implements ProductOptionValuePriceSaverInterf
                 $this->createPriceEntity($moneyValueTransfer, $productOptionValueTransfer->getIdProductOptionValue());
                 continue;
             }
+
             $this->updatePriceEntity($priceEntity, $moneyValueTransfer);
         }
     }

--- a/src/Spryker/Zed/ProductOption/Business/OptionGroup/ProductOptionValueReader.php
+++ b/src/Spryker/Zed/ProductOption/Business/OptionGroup/ProductOptionValueReader.php
@@ -30,8 +30,10 @@ class ProductOptionValueReader implements ProductOptionValueReaderInterface
      * @param \Spryker\Zed\ProductOption\Business\OptionGroup\ProductOptionValuePriceReaderInterface $productOptionValuePriceReader
      * @param \Spryker\Zed\ProductOption\Persistence\ProductOptionQueryContainerInterface $productOptionQueryContainer
      */
-    public function __construct(ProductOptionValuePriceReaderInterface $productOptionValuePriceReader, ProductOptionQueryContainerInterface $productOptionQueryContainer)
-    {
+    public function __construct(
+        ProductOptionValuePriceReaderInterface $productOptionValuePriceReader,
+        ProductOptionQueryContainerInterface $productOptionQueryContainer
+    ) {
         $this->productOptionValuePriceReader = $productOptionValuePriceReader;
         $this->productOptionQueryContainer = $productOptionQueryContainer;
     }
@@ -78,8 +80,9 @@ class ProductOptionValueReader implements ProductOptionValueReaderInterface
      *
      * @return \Generated\Shared\Transfer\ProductOptionCollectionTransfer
      */
-    public function getProductOptionCollectionByProductOptionCriteria(ProductOptionCriteriaTransfer $productOptionCriteriaTransfer): ProductOptionCollectionTransfer
-    {
+    public function getProductOptionCollectionByProductOptionCriteria(
+        ProductOptionCriteriaTransfer $productOptionCriteriaTransfer
+    ): ProductOptionCollectionTransfer {
         $productOptionValueEntities = $this->productOptionQueryContainer
             ->queryProductOptionByProductOptionCriteria($productOptionCriteriaTransfer)
             ->find();

--- a/src/Spryker/Zed/ProductOption/Business/OptionGroup/ProductOptionValueSaver.php
+++ b/src/Spryker/Zed/ProductOption/Business/OptionGroup/ProductOptionValueSaver.php
@@ -125,8 +125,10 @@ class ProductOptionValueSaver implements ProductOptionValueSaverInterface
         SpyProductOptionValue $producOptionValueEntity,
         ProductOptionValueTransfer $productOptionValueTransfer
     ) {
-        if (!$producOptionValueEntity->getValue() &&
-            strpos($productOptionValueTransfer->getValue(), ProductOptionConfig::PRODUCT_OPTION_TRANSLATION_PREFIX) === false) {
+        if (
+            !$producOptionValueEntity->getValue() &&
+            strpos($productOptionValueTransfer->getValue(), ProductOptionConfig::PRODUCT_OPTION_TRANSLATION_PREFIX) === false
+        ) {
             $productOptionValueTransfer->setValue(
                 ProductOptionConfig::PRODUCT_OPTION_TRANSLATION_PREFIX . $productOptionValueTransfer->getValue()
             );

--- a/src/Spryker/Zed/ProductOption/Business/OptionGroup/ProductOptionValueSaverInterface.php
+++ b/src/Spryker/Zed/ProductOption/Business/OptionGroup/ProductOptionValueSaverInterface.php
@@ -4,6 +4,7 @@
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
 namespace Spryker\Zed\ProductOption\Business\OptionGroup;
 
 use Generated\Shared\Transfer\ProductOptionGroupTransfer;

--- a/src/Spryker/Zed/ProductOption/Business/OptionGroup/TranslationSaverInterface.php
+++ b/src/Spryker/Zed/ProductOption/Business/OptionGroup/TranslationSaverInterface.php
@@ -4,6 +4,7 @@
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
 namespace Spryker\Zed\ProductOption\Business\OptionGroup;
 
 use Generated\Shared\Transfer\ProductOptionGroupTransfer;

--- a/src/Spryker/Zed/ProductOption/Business/ProductOptionBusinessFactory.php
+++ b/src/Spryker/Zed/ProductOption/Business/ProductOptionBusinessFactory.php
@@ -23,6 +23,8 @@ use Spryker\Zed\ProductOption\Business\OptionGroup\ProductOptionValueReader;
 use Spryker\Zed\ProductOption\Business\OptionGroup\ProductOptionValueSaver;
 use Spryker\Zed\ProductOption\Business\OptionGroup\TranslationSaver;
 use Spryker\Zed\ProductOption\Business\PlaceOrder\ProductOptionOrderSaver;
+use Spryker\Zed\ProductOption\Business\Reader\ProductOptionReader;
+use Spryker\Zed\ProductOption\Business\Reader\ProductOptionReaderInterface;
 use Spryker\Zed\ProductOption\ProductOptionDependencyProvider;
 
 /**
@@ -42,6 +44,19 @@ class ProductOptionBusinessFactory extends AbstractBusinessFactory
             $this->getQueryContainer(),
             $this->getGlossaryFacade(),
             $this->getLocaleFacade()
+        );
+    }
+
+    /**
+     * @return \Spryker\Zed\ProductOption\Business\Reader\ProductOptionReaderInterface
+     */
+    public function createProductOptionReader(): ProductOptionReaderInterface
+    {
+        return new ProductOptionReader(
+            $this->getRepository(),
+            $this->getCurrencyFacade(),
+            $this->getStoreFacade(),
+            $this->getPriceFacade()
         );
     }
 

--- a/src/Spryker/Zed/ProductOption/Business/ProductOptionFacade.php
+++ b/src/Spryker/Zed/ProductOption/Business/ProductOptionFacade.php
@@ -26,7 +26,7 @@ use Spryker\Zed\Kernel\Business\AbstractFacade;
 class ProductOptionFacade extends AbstractFacade implements ProductOptionFacadeInterface
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -42,7 +42,7 @@ class ProductOptionFacade extends AbstractFacade implements ProductOptionFacadeI
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -58,7 +58,7 @@ class ProductOptionFacade extends AbstractFacade implements ProductOptionFacadeI
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -75,7 +75,7 @@ class ProductOptionFacade extends AbstractFacade implements ProductOptionFacadeI
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -92,7 +92,7 @@ class ProductOptionFacade extends AbstractFacade implements ProductOptionFacadeI
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -108,7 +108,7 @@ class ProductOptionFacade extends AbstractFacade implements ProductOptionFacadeI
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -127,7 +127,7 @@ class ProductOptionFacade extends AbstractFacade implements ProductOptionFacadeI
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -144,7 +144,7 @@ class ProductOptionFacade extends AbstractFacade implements ProductOptionFacadeI
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -160,7 +160,7 @@ class ProductOptionFacade extends AbstractFacade implements ProductOptionFacadeI
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -177,7 +177,7 @@ class ProductOptionFacade extends AbstractFacade implements ProductOptionFacadeI
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -193,7 +193,7 @@ class ProductOptionFacade extends AbstractFacade implements ProductOptionFacadeI
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -209,7 +209,7 @@ class ProductOptionFacade extends AbstractFacade implements ProductOptionFacadeI
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -225,7 +225,7 @@ class ProductOptionFacade extends AbstractFacade implements ProductOptionFacadeI
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -255,7 +255,7 @@ class ProductOptionFacade extends AbstractFacade implements ProductOptionFacadeI
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -263,15 +263,33 @@ class ProductOptionFacade extends AbstractFacade implements ProductOptionFacadeI
      *
      * @return \Generated\Shared\Transfer\ProductOptionCollectionTransfer
      */
-    public function getProductOptionCollectionByProductOptionCriteria(ProductOptionCriteriaTransfer $productOptionCriteriaTransfer): ProductOptionCollectionTransfer
-    {
+    public function getProductOptionCollectionByProductOptionCriteria(
+        ProductOptionCriteriaTransfer $productOptionCriteriaTransfer
+    ): ProductOptionCollectionTransfer {
         return $this->getFactory()
             ->createProductOptionValueReader()
             ->getProductOptionCollectionByProductOptionCriteria($productOptionCriteriaTransfer);
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\ProductOptionCriteriaTransfer $productOptionCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductOptionCollectionTransfer
+     */
+    public function get(
+        ProductOptionCriteriaTransfer $productOptionCriteriaTransfer
+    ): ProductOptionCollectionTransfer {
+        return $this->getFactory()
+            ->createProductOptionReader()
+            ->get($productOptionCriteriaTransfer);
+    }
+
+    /**
+     * {@inheritDoc}
      *
      * @api
      *
@@ -287,7 +305,7 @@ class ProductOptionFacade extends AbstractFacade implements ProductOptionFacadeI
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -305,7 +323,7 @@ class ProductOptionFacade extends AbstractFacade implements ProductOptionFacadeI
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -321,7 +339,7 @@ class ProductOptionFacade extends AbstractFacade implements ProductOptionFacadeI
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *

--- a/src/Spryker/Zed/ProductOption/Business/ProductOptionFacadeInterface.php
+++ b/src/Spryker/Zed/ProductOption/Business/ProductOptionFacadeInterface.php
@@ -244,7 +244,9 @@ interface ProductOptionFacadeInterface
      *
      * @return \Generated\Shared\Transfer\ProductOptionCollectionTransfer
      */
-    public function getProductOptionCollectionByProductOptionCriteria(ProductOptionCriteriaTransfer $productOptionCriteriaTransfer): ProductOptionCollectionTransfer;
+    public function getProductOptionCollectionByProductOptionCriteria(
+        ProductOptionCriteriaTransfer $productOptionCriteriaTransfer
+    ): ProductOptionCollectionTransfer;
 
     /**
      * Specification:
@@ -264,7 +266,7 @@ interface ProductOptionFacadeInterface
      *
      * @api
      *
-     * @deprecated Use checkProductOptionGroupExistenceByProductOptionValueId() instead
+     * @deprecated Use {@link checkProductOptionGroupExistenceByProductOptionValueId()} instead
      *
      * @param int $idProductOptionValue
      *

--- a/src/Spryker/Zed/ProductOption/Business/Reader/ProductOptionReader.php
+++ b/src/Spryker/Zed/ProductOption/Business/Reader/ProductOptionReader.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\ProductOption\Business\Reader;
+
+use Generated\Shared\Transfer\ProductOptionCollectionTransfer;
+use Generated\Shared\Transfer\ProductOptionCriteriaTransfer;
+use Generated\Shared\Transfer\ProductOptionTransfer;
+use Spryker\Zed\ProductOption\Dependency\Facade\ProductOptionToCurrencyFacadeInterface;
+use Spryker\Zed\ProductOption\Dependency\Facade\ProductOptionToPriceFacadeInterface;
+use Spryker\Zed\ProductOption\Dependency\Facade\ProductOptionToStoreFacadeInterface;
+use Spryker\Zed\ProductOption\Persistence\ProductOptionRepositoryInterface;
+
+class ProductOptionReader implements ProductOptionReaderInterface
+{
+    /**
+     * @var \Spryker\Zed\ProductOption\Persistence\ProductOptionRepositoryInterface
+     */
+    protected $productOptionRepository;
+
+    /**
+     * @var \Spryker\Zed\ProductOption\Dependency\Facade\ProductOptionToCurrencyFacadeInterface
+     */
+    protected $currencyFacade;
+
+    /**
+     * @var \Spryker\Zed\ProductOption\Dependency\Facade\ProductOptionToStoreFacadeInterface
+     */
+    protected $storeFacade;
+
+    /**
+     * @var \Spryker\Zed\ProductOption\Dependency\Facade\ProductOptionToPriceFacadeInterface
+     */
+    protected $priceFacade;
+
+    /**
+     * @param \Spryker\Zed\ProductOption\Persistence\ProductOptionRepositoryInterface $productOptionRepository
+     * @param \Spryker\Zed\ProductOption\Dependency\Facade\ProductOptionToCurrencyFacadeInterface $currencyFacade
+     * @param \Spryker\Zed\ProductOption\Dependency\Facade\ProductOptionToStoreFacadeInterface $storeFacade
+     * @param \Spryker\Zed\ProductOption\Dependency\Facade\ProductOptionToPriceFacadeInterface $priceFacade
+     */
+    public function __construct(
+        ProductOptionRepositoryInterface $productOptionRepository,
+        ProductOptionToCurrencyFacadeInterface $currencyFacade,
+        ProductOptionToStoreFacadeInterface $storeFacade,
+        ProductOptionToPriceFacadeInterface $priceFacade
+    ) {
+        $this->productOptionRepository = $productOptionRepository;
+        $this->currencyFacade = $currencyFacade;
+        $this->storeFacade = $storeFacade;
+        $this->priceFacade = $priceFacade;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\ProductOptionCriteriaTransfer $productOptionCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductOptionCollectionTransfer
+     */
+    public function get(
+        ProductOptionCriteriaTransfer $productOptionCriteriaTransfer
+    ): ProductOptionCollectionTransfer {
+        $productOptionValueTransfers = $this->productOptionRepository
+            ->get($productOptionCriteriaTransfer);
+
+        return $this->createProductOptionCollectionTransfer(
+            $productOptionValueTransfers,
+            $productOptionCriteriaTransfer->getPriceMode()
+        );
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\ProductOptionValueTransfer[] $productOptionValueTransfers
+     * @param string|null $priceMode
+     *
+     * @return \Generated\Shared\Transfer\ProductOptionCollectionTransfer
+     */
+    protected function createProductOptionCollectionTransfer(
+        array $productOptionValueTransfers,
+        ?string $priceMode = null
+    ): ProductOptionCollectionTransfer {
+        $productOptionCollectionTransfer = new ProductOptionCollectionTransfer();
+        $priceMode = $priceMode ?? $this->priceFacade->getDefaultPriceMode();
+        $grossPriceModeIdentifier = $this->priceFacade->getGrossPriceModeIdentifier();
+
+        foreach ($productOptionValueTransfers as $productOptionValueTransfer) {
+            $productOptionTransfer = (new ProductOptionTransfer())
+                ->fromArray($productOptionValueTransfer->toArray(), true)
+                ->setGroupName($productOptionValueTransfer->getProductOptionGroup()->getName());
+
+            if ($productOptionValueTransfer->getPrices()->offsetExists(0)) {
+                $moneyValueTransfer = $productOptionValueTransfer->getPrices()->offsetGet(0);
+                $productOptionTransfer
+                    ->setUnitGrossPrice($moneyValueTransfer->getGrossAmount())
+                    ->setUnitNetPrice($moneyValueTransfer->getNetAmount());
+
+                $productOptionTransfer->setUnitPrice(
+                    $this->resolveUnitPrice($productOptionTransfer, $priceMode, $grossPriceModeIdentifier)
+                );
+            }
+
+            $productOptionCollectionTransfer->addProductOption($productOptionTransfer);
+        }
+
+        return $productOptionCollectionTransfer;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\ProductOptionTransfer $productOptionTransfer
+     * @param string $priceMode
+     * @param string $grossPriceModeIdentifier
+     *
+     * @return int|null
+     */
+    protected function resolveUnitPrice(
+        ProductOptionTransfer $productOptionTransfer,
+        string $priceMode,
+        string $grossPriceModeIdentifier
+    ): ?int {
+        if ($priceMode === $grossPriceModeIdentifier) {
+            return $productOptionTransfer->getUnitGrossPrice();
+        }
+
+        return $productOptionTransfer->getUnitNetPrice();
+    }
+}

--- a/src/Spryker/Zed/ProductOption/Business/Reader/ProductOptionReaderInterface.php
+++ b/src/Spryker/Zed/ProductOption/Business/Reader/ProductOptionReaderInterface.php
@@ -5,25 +5,19 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
-namespace Spryker\Zed\ProductOption\Persistence;
+namespace Spryker\Zed\ProductOption\Business\Reader;
 
+use Generated\Shared\Transfer\ProductOptionCollectionTransfer;
 use Generated\Shared\Transfer\ProductOptionCriteriaTransfer;
 
-interface ProductOptionRepositoryInterface
+interface ProductOptionReaderInterface
 {
-    /**
-     * @param int[] $productAbstractIds
-     *
-     * @return \Generated\Shared\Transfer\ProductAbstractOptionGroupStatusTransfer[]
-     */
-    public function getProductAbstractOptionGroupStatusesByProductAbstractIds(array $productAbstractIds): array;
-
     /**
      * @param \Generated\Shared\Transfer\ProductOptionCriteriaTransfer $productOptionCriteriaTransfer
      *
-     * @return \Generated\Shared\Transfer\ProductOptionValueTransfer[]
+     * @return \Generated\Shared\Transfer\ProductOptionCollectionTransfer
      */
     public function get(
         ProductOptionCriteriaTransfer $productOptionCriteriaTransfer
-    ): array;
+    ): ProductOptionCollectionTransfer;
 }

--- a/src/Spryker/Zed/ProductOption/Communication/Controller/BaseOptionController.php
+++ b/src/Spryker/Zed/ProductOption/Communication/Controller/BaseOptionController.php
@@ -14,6 +14,7 @@ use Symfony\Component\HttpFoundation\Request;
  * @method \Spryker\Zed\ProductOption\Communication\ProductOptionCommunicationFactory getFactory()
  * @method \Spryker\Zed\ProductOption\Persistence\ProductOptionQueryContainerInterface getQueryContainer()
  * @method \Spryker\Zed\ProductOption\Business\ProductOptionFacadeInterface getFacade()
+ * @method \Spryker\Zed\ProductOption\Persistence\ProductOptionRepositoryInterface getRepository()
  */
 class BaseOptionController extends AbstractController
 {

--- a/src/Spryker/Zed/ProductOption/Communication/Controller/IndexController.php
+++ b/src/Spryker/Zed/ProductOption/Communication/Controller/IndexController.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
  * @method \Spryker\Zed\ProductOption\Communication\ProductOptionCommunicationFactory getFactory()
  * @method \Spryker\Zed\ProductOption\Persistence\ProductOptionQueryContainerInterface getQueryContainer()
  * @method \Spryker\Zed\ProductOption\Business\ProductOptionFacadeInterface getFacade()
+ * @method \Spryker\Zed\ProductOption\Persistence\ProductOptionRepositoryInterface getRepository()
  */
 class IndexController extends AbstractController
 {

--- a/src/Spryker/Zed/ProductOption/Communication/Form/DataProvider/ProductOptionGroupDataProvider.php
+++ b/src/Spryker/Zed/ProductOption/Communication/Form/DataProvider/ProductOptionGroupDataProvider.php
@@ -4,6 +4,7 @@
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
 namespace Spryker\Zed\ProductOption\Communication\Form\DataProvider;
 
 use Generated\Shared\Transfer\ProductOptionGroupTransfer;

--- a/src/Spryker/Zed/ProductOption/Communication/Form/ProductOptionGroupForm.php
+++ b/src/Spryker/Zed/ProductOption/Communication/Form/ProductOptionGroupForm.php
@@ -27,6 +27,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
  * @method \Spryker\Zed\ProductOption\Communication\ProductOptionCommunicationFactory getFactory()
  * @method \Spryker\Zed\ProductOption\Persistence\ProductOptionQueryContainerInterface getQueryContainer()
  * @method \Spryker\Zed\ProductOption\ProductOptionConfig getConfig()
+ * @method \Spryker\Zed\ProductOption\Persistence\ProductOptionRepositoryInterface getRepository()
  */
 class ProductOptionGroupForm extends AbstractType
 {

--- a/src/Spryker/Zed/ProductOption/Communication/Form/ProductOptionTranslationForm.php
+++ b/src/Spryker/Zed/ProductOption/Communication/Form/ProductOptionTranslationForm.php
@@ -20,6 +20,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
  * @method \Spryker\Zed\ProductOption\Communication\ProductOptionCommunicationFactory getFactory()
  * @method \Spryker\Zed\ProductOption\Persistence\ProductOptionQueryContainerInterface getQueryContainer()
  * @method \Spryker\Zed\ProductOption\ProductOptionConfig getConfig()
+ * @method \Spryker\Zed\ProductOption\Persistence\ProductOptionRepositoryInterface getRepository()
  */
 class ProductOptionTranslationForm extends AbstractType
 {

--- a/src/Spryker/Zed/ProductOption/Communication/Form/ProductOptionValueForm.php
+++ b/src/Spryker/Zed/ProductOption/Communication/Form/ProductOptionValueForm.php
@@ -24,6 +24,7 @@ use Symfony\Component\Validator\Constraints\Regex;
  * @method \Spryker\Zed\ProductOption\Communication\ProductOptionCommunicationFactory getFactory()
  * @method \Spryker\Zed\ProductOption\Persistence\ProductOptionQueryContainerInterface getQueryContainer()
  * @method \Spryker\Zed\ProductOption\ProductOptionConfig getConfig()
+ * @method \Spryker\Zed\ProductOption\Persistence\ProductOptionRepositoryInterface getRepository()
  */
 class ProductOptionValueForm extends AbstractType
 {

--- a/src/Spryker/Zed/ProductOption/Communication/Plugin/Checkout/ProductOptionOrderSaverPlugin.php
+++ b/src/Spryker/Zed/ProductOption/Communication/Plugin/Checkout/ProductOptionOrderSaverPlugin.php
@@ -23,6 +23,8 @@ use Spryker\Zed\Kernel\Communication\AbstractPlugin;
 class ProductOptionOrderSaverPlugin extends AbstractPlugin implements CheckoutDoSaveOrderInterface
 {
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer

--- a/src/Spryker/Zed/ProductOption/Communication/Plugin/ProductOptionOrderSaverPlugin.php
+++ b/src/Spryker/Zed/ProductOption/Communication/Plugin/ProductOptionOrderSaverPlugin.php
@@ -23,7 +23,7 @@ use Spryker\Zed\Kernel\Communication\AbstractPlugin;
 class ProductOptionOrderSaverPlugin extends AbstractPlugin implements CheckoutSaveOrderInterface
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *

--- a/src/Spryker/Zed/ProductOption/Communication/Plugin/ProductOptionTaxRateCalculatorPlugin.php
+++ b/src/Spryker/Zed/ProductOption/Communication/Plugin/ProductOptionTaxRateCalculatorPlugin.php
@@ -20,7 +20,7 @@ use Spryker\Zed\Kernel\Communication\AbstractPlugin;
 class ProductOptionTaxRateCalculatorPlugin extends AbstractPlugin implements CalculatorPluginInterface
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *

--- a/src/Spryker/Zed/ProductOption/Communication/Plugin/Sales/ProductOptionGroupIdHydratorPlugin.php
+++ b/src/Spryker/Zed/ProductOption/Communication/Plugin/Sales/ProductOptionGroupIdHydratorPlugin.php
@@ -20,7 +20,7 @@ use Spryker\Zed\Sales\Dependency\Plugin\HydrateOrderPluginInterface;
 class ProductOptionGroupIdHydratorPlugin extends AbstractPlugin implements HydrateOrderPluginInterface
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *

--- a/src/Spryker/Zed/ProductOption/Communication/Plugin/Sales/ProductOptionOrderHydratePlugin.php
+++ b/src/Spryker/Zed/ProductOption/Communication/Plugin/Sales/ProductOptionOrderHydratePlugin.php
@@ -20,7 +20,7 @@ use Spryker\Zed\Sales\Dependency\Plugin\HydrateOrderPluginInterface;
 class ProductOptionOrderHydratePlugin extends AbstractPlugin implements HydrateOrderPluginInterface
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *

--- a/src/Spryker/Zed/ProductOption/Communication/Plugin/Sales/ProductOptionSortHydratePlugin.php
+++ b/src/Spryker/Zed/ProductOption/Communication/Plugin/Sales/ProductOptionSortHydratePlugin.php
@@ -20,7 +20,7 @@ use Spryker\Zed\Sales\Dependency\Plugin\HydrateOrderPluginInterface;
 class ProductOptionSortHydratePlugin extends AbstractPlugin implements HydrateOrderPluginInterface
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *

--- a/src/Spryker/Zed/ProductOption/Communication/ProductOptionCommunicationFactory.php
+++ b/src/Spryker/Zed/ProductOption/Communication/ProductOptionCommunicationFactory.php
@@ -27,6 +27,7 @@ use Symfony\Component\Form\FormInterface;
  * @method \Spryker\Zed\ProductOption\ProductOptionConfig getConfig()
  * @method \Spryker\Zed\ProductOption\Persistence\ProductOptionQueryContainerInterface getQueryContainer()
  * @method \Spryker\Zed\ProductOption\Business\ProductOptionFacadeInterface getFacade()
+ * @method \Spryker\Zed\ProductOption\Persistence\ProductOptionRepositoryInterface getRepository()
  */
 class ProductOptionCommunicationFactory extends AbstractCommunicationFactory
 {

--- a/src/Spryker/Zed/ProductOption/Dependency/Facade/ProductOptionToGlossaryFacadeInterface.php
+++ b/src/Spryker/Zed/ProductOption/Dependency/Facade/ProductOptionToGlossaryFacadeInterface.php
@@ -4,6 +4,7 @@
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
 namespace Spryker\Zed\ProductOption\Dependency\Facade;
 
 use Generated\Shared\Transfer\LocaleTransfer;

--- a/src/Spryker/Zed/ProductOption/Dependency/Facade/ProductOptionToMoneyFacadeInterface.php
+++ b/src/Spryker/Zed/ProductOption/Dependency/Facade/ProductOptionToMoneyFacadeInterface.php
@@ -4,6 +4,7 @@
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
 namespace Spryker\Zed\ProductOption\Dependency\Facade;
 
 use Generated\Shared\Transfer\MoneyTransfer;

--- a/src/Spryker/Zed/ProductOption/Dependency/QueryContainer/ProductOptionToCountryQueryContainerInterface.php
+++ b/src/Spryker/Zed/ProductOption/Dependency/QueryContainer/ProductOptionToCountryQueryContainerInterface.php
@@ -4,6 +4,7 @@
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
 namespace Spryker\Zed\ProductOption\Dependency\QueryContainer;
 
 interface ProductOptionToCountryQueryContainerInterface

--- a/src/Spryker/Zed/ProductOption/Dependency/QueryContainer/ProductOptionToSalesQueryContainerInterface.php
+++ b/src/Spryker/Zed/ProductOption/Dependency/QueryContainer/ProductOptionToSalesQueryContainerInterface.php
@@ -4,6 +4,7 @@
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
 namespace Spryker\Zed\ProductOption\Dependency\QueryContainer;
 
 interface ProductOptionToSalesQueryContainerInterface

--- a/src/Spryker/Zed/ProductOption/Persistence/ProductOptionQueryContainer.php
+++ b/src/Spryker/Zed/ProductOption/Persistence/ProductOptionQueryContainer.php
@@ -32,6 +32,8 @@ class ProductOptionQueryContainer extends AbstractQueryContainer implements Prod
     public const COL_ID_PRODUCT_OPTION_VALUE = 'idProductOptionValue';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param string $sku
@@ -46,6 +48,8 @@ class ProductOptionQueryContainer extends AbstractQueryContainer implements Prod
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \Orm\Zed\ProductOption\Persistence\SpyProductAbstractProductOptionGroupQuery
@@ -57,6 +61,8 @@ class ProductOptionQueryContainer extends AbstractQueryContainer implements Prod
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \Orm\Zed\ProductOption\Persistence\SpyProductOptionGroupQuery
@@ -68,6 +74,8 @@ class ProductOptionQueryContainer extends AbstractQueryContainer implements Prod
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \Orm\Zed\ProductOption\Persistence\SpyProductOptionValueQuery
@@ -79,6 +87,8 @@ class ProductOptionQueryContainer extends AbstractQueryContainer implements Prod
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \Orm\Zed\Sales\Persistence\SpySalesOrderItemQuery
@@ -91,6 +101,8 @@ class ProductOptionQueryContainer extends AbstractQueryContainer implements Prod
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param int $idProductOptionValue
@@ -105,6 +117,8 @@ class ProductOptionQueryContainer extends AbstractQueryContainer implements Prod
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param int $idProductOptionValue
@@ -122,6 +136,8 @@ class ProductOptionQueryContainer extends AbstractQueryContainer implements Prod
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param \Generated\Shared\Transfer\ProductOptionCriteriaTransfer $productOptionCriteriaTransfer
@@ -143,6 +159,8 @@ class ProductOptionQueryContainer extends AbstractQueryContainer implements Prod
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param string $sku
@@ -157,6 +175,8 @@ class ProductOptionQueryContainer extends AbstractQueryContainer implements Prod
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param string $value
@@ -171,6 +191,8 @@ class ProductOptionQueryContainer extends AbstractQueryContainer implements Prod
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param int $idProductOptionGroup
@@ -185,6 +207,8 @@ class ProductOptionQueryContainer extends AbstractQueryContainer implements Prod
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param int $idProductOptionGroup
@@ -206,6 +230,8 @@ class ProductOptionQueryContainer extends AbstractQueryContainer implements Prod
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param int $idProductOptionGroup
@@ -219,6 +245,8 @@ class ProductOptionQueryContainer extends AbstractQueryContainer implements Prod
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param int $idProductOptionValue
@@ -233,6 +261,8 @@ class ProductOptionQueryContainer extends AbstractQueryContainer implements Prod
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param string $groupName
@@ -247,6 +277,8 @@ class ProductOptionQueryContainer extends AbstractQueryContainer implements Prod
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param int $idProductOptionGroup
@@ -303,6 +335,8 @@ class ProductOptionQueryContainer extends AbstractQueryContainer implements Prod
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param string $term
@@ -330,6 +364,8 @@ class ProductOptionQueryContainer extends AbstractQueryContainer implements Prod
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param string $term
@@ -391,6 +427,8 @@ class ProductOptionQueryContainer extends AbstractQueryContainer implements Prod
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param int[] $allIdOptionValueUsages

--- a/src/Spryker/Zed/ProductOption/Persistence/ProductOptionQueryContainerInterface.php
+++ b/src/Spryker/Zed/ProductOption/Persistence/ProductOptionQueryContainerInterface.php
@@ -14,6 +14,9 @@ use Orm\Zed\ProductOption\Persistence\SpyProductOptionGroupQuery;
 interface ProductOptionQueryContainerInterface
 {
     /**
+     * Specification:
+     * - TODO: Add method specification.
+     *
      * @api
      *
      * @param string $sku
@@ -25,6 +28,9 @@ interface ProductOptionQueryContainerInterface
     public function queryProductAbstractBySku($sku);
 
     /**
+     * Specification:
+     * - TODO: Add method specification.
+     *
      * @api
      *
      * @return \Orm\Zed\ProductOption\Persistence\SpyProductOptionGroupQuery
@@ -32,6 +38,9 @@ interface ProductOptionQueryContainerInterface
     public function queryAllProductOptionGroups();
 
     /**
+     * Specification:
+     * - TODO: Add method specification.
+     *
      * @api
      *
      * @return \Orm\Zed\ProductOption\Persistence\SpyProductAbstractProductOptionGroupQuery
@@ -39,6 +48,9 @@ interface ProductOptionQueryContainerInterface
     public function queryAllProductAbstractProductOptionGroups();
 
     /**
+     * Specification:
+     * - TODO: Add method specification.
+     *
      * @api
      *
      * @return \Orm\Zed\ProductOption\Persistence\SpyProductOptionValueQuery
@@ -46,6 +58,9 @@ interface ProductOptionQueryContainerInterface
     public function queryAllProductOptionValues();
 
     /**
+     * Specification:
+     * - TODO: Add method specification.
+     *
      * @api
      *
      * @param int $idProductOptionValue
@@ -55,6 +70,9 @@ interface ProductOptionQueryContainerInterface
     public function queryProductOptionByValueId($idProductOptionValue);
 
     /**
+     * Specification:
+     * - TODO: Add method specification.
+     *
      * @api
      *
      * @param \Generated\Shared\Transfer\ProductOptionCriteriaTransfer $productOptionCriteriaTransfer
@@ -64,6 +82,9 @@ interface ProductOptionQueryContainerInterface
     public function queryProductOptionByProductOptionCriteria(ProductOptionCriteriaTransfer $productOptionCriteriaTransfer);
 
     /**
+     * Specification:
+     * - TODO: Add method specification.
+     *
      * @api
      *
      * @param string $sku
@@ -73,6 +94,9 @@ interface ProductOptionQueryContainerInterface
     public function queryProductOptionValueBySku($sku);
 
     /**
+     * Specification:
+     * - TODO: Add method specification.
+     *
      * @api
      *
      * @param string $groupName
@@ -82,6 +106,9 @@ interface ProductOptionQueryContainerInterface
     public function queryProductOptionGroupByName($groupName);
 
     /**
+     * Specification:
+     * - TODO: Add method specification.
+     *
      * @api
      *
      * @param int[] $allIdOptionValueUsages
@@ -92,6 +119,9 @@ interface ProductOptionQueryContainerInterface
     public function queryTaxSetByIdProductOptionValueAndCountryIso2Code($allIdOptionValueUsages, $countryIso2Code);
 
     /**
+     * Specification:
+     * - TODO: Add method specification.
+     *
      * @api
      *
      * @param int $idProductOptionGroup
@@ -101,6 +131,9 @@ interface ProductOptionQueryContainerInterface
     public function queryProductOptionGroupById($idProductOptionGroup);
 
     /**
+     * Specification:
+     * - TODO: Add method specification.
+     *
      * @api
      *
      * @param int $idProductOptionGroup
@@ -110,6 +143,9 @@ interface ProductOptionQueryContainerInterface
     public function queryProductOptionGroupWithProductOptionValuesAndProductOptionValuePricesById($idProductOptionGroup);
 
     /**
+     * Specification:
+     * - TODO: Add method specification.
+     *
      * @api
      *
      * @param int $idProductOptionGroup
@@ -119,6 +155,9 @@ interface ProductOptionQueryContainerInterface
     public function queryActiveProductOptionGroupWithProductOptionValuesAndProductOptionValuePricesById($idProductOptionGroup);
 
     /**
+     * Specification:
+     * - TODO: Add method specification.
+     *
      * @api
      *
      * @param int $idProductOptionValue
@@ -128,6 +167,9 @@ interface ProductOptionQueryContainerInterface
     public function queryProductOptionValuePricesByIdProductOptionValue($idProductOptionValue);
 
     /**
+     * Specification:
+     * - TODO: Add method specification.
+     *
      * @api
      *
      * @param int $idProductOptionGroup
@@ -138,6 +180,9 @@ interface ProductOptionQueryContainerInterface
     public function queryAbstractProductsByOptionGroupId($idProductOptionGroup, LocaleTransfer $localeTransfer);
 
     /**
+     * Specification:
+     * - TODO: Add method specification.
+     *
      * @api
      *
      * @param string $term
@@ -149,6 +194,9 @@ interface ProductOptionQueryContainerInterface
     public function queryProductsAbstractBySearchTermForAssignment($term, $idProductOptionGroup, LocaleTransfer $localeTransfer);
 
     /**
+     * Specification:
+     * - TODO: Add method specification.
+     *
      * @api
      *
      * @param string $value
@@ -158,6 +206,9 @@ interface ProductOptionQueryContainerInterface
     public function queryProductOptionValue($value);
 
     /**
+     * Specification:
+     * - TODO: Add method specification.
+     *
      * @api
      *
      * @return \Orm\Zed\Sales\Persistence\SpySalesOrderItemQuery
@@ -165,6 +216,9 @@ interface ProductOptionQueryContainerInterface
     public function querySalesOrder();
 
     /**
+     * Specification:
+     * - TODO: Add method specification.
+     *
      * @api
      *
      * @param int $idProductOptionValue

--- a/src/Spryker/Zed/ProductOption/Persistence/Propel/AbstractSpyProductAbstractProductOptionGroup.php
+++ b/src/Spryker/Zed/ProductOption/Persistence/Propel/AbstractSpyProductAbstractProductOptionGroup.php
@@ -17,7 +17,6 @@ use Orm\Zed\ProductOption\Persistence\Base\SpyProductAbstractProductOptionGroup 
  * You should add additional methods to this class to meet the
  * application requirements. This class will only be generated as
  * long as it does not already exist in the output directory.
- *
  */
 class AbstractSpyProductAbstractProductOptionGroup extends BaseSpyProductAbstractProductOptionGroup
 {

--- a/src/Spryker/Zed/ProductOption/Persistence/Propel/AbstractSpyProductAbstractProductOptionGroupQuery.php
+++ b/src/Spryker/Zed/ProductOption/Persistence/Propel/AbstractSpyProductAbstractProductOptionGroupQuery.php
@@ -17,7 +17,6 @@ use Orm\Zed\ProductOption\Persistence\Base\SpyProductAbstractProductOptionGroupQ
  * You should add additional methods to this class to meet the
  * application requirements. This class will only be generated as
  * long as it does not already exist in the output directory.
- *
  */
 class AbstractSpyProductAbstractProductOptionGroupQuery extends BaseSpyProductAbstractProductOptionGroupQuery
 {

--- a/src/Spryker/Zed/ProductOption/Persistence/Propel/AbstractSpyProductOptionGroup.php
+++ b/src/Spryker/Zed/ProductOption/Persistence/Propel/AbstractSpyProductOptionGroup.php
@@ -17,7 +17,6 @@ use Orm\Zed\ProductOption\Persistence\Base\SpyProductOptionGroup as BaseSpyProdu
  * You should add additional methods to this class to meet the
  * application requirements. This class will only be generated as
  * long as it does not already exist in the output directory.
- *
  */
 class AbstractSpyProductOptionGroup extends BaseSpyProductOptionGroup
 {

--- a/src/Spryker/Zed/ProductOption/Persistence/Propel/AbstractSpyProductOptionGroupQuery.php
+++ b/src/Spryker/Zed/ProductOption/Persistence/Propel/AbstractSpyProductOptionGroupQuery.php
@@ -17,7 +17,6 @@ use Orm\Zed\ProductOption\Persistence\Base\SpyProductOptionGroupQuery as BaseSpy
  * You should add additional methods to this class to meet the
  * application requirements. This class will only be generated as
  * long as it does not already exist in the output directory.
- *
  */
 class AbstractSpyProductOptionGroupQuery extends BaseSpyProductOptionGroupQuery
 {

--- a/src/Spryker/Zed/ProductOption/Persistence/Propel/AbstractSpyProductOptionValue.php
+++ b/src/Spryker/Zed/ProductOption/Persistence/Propel/AbstractSpyProductOptionValue.php
@@ -17,7 +17,6 @@ use Orm\Zed\ProductOption\Persistence\Base\SpyProductOptionValue as BaseSpyProdu
  * You should add additional methods to this class to meet the
  * application requirements. This class will only be generated as
  * long as it does not already exist in the output directory.
- *
  */
 class AbstractSpyProductOptionValue extends BaseSpyProductOptionValue
 {

--- a/src/Spryker/Zed/ProductOption/Persistence/Propel/AbstractSpyProductOptionValuePrice.php
+++ b/src/Spryker/Zed/ProductOption/Persistence/Propel/AbstractSpyProductOptionValuePrice.php
@@ -17,7 +17,6 @@ use Orm\Zed\ProductOption\Persistence\Base\SpyProductOptionValuePrice as BaseSpy
  * You should add additional methods to this class to meet the
  * application requirements. This class will only be generated as
  * long as it does not already exist in the output directory.
- *
  */
 class AbstractSpyProductOptionValuePrice extends BaseSpyProductOptionValuePrice
 {

--- a/src/Spryker/Zed/ProductOption/Persistence/Propel/AbstractSpyProductOptionValuePriceQuery.php
+++ b/src/Spryker/Zed/ProductOption/Persistence/Propel/AbstractSpyProductOptionValuePriceQuery.php
@@ -17,7 +17,6 @@ use Orm\Zed\ProductOption\Persistence\Base\SpyProductOptionValuePriceQuery as Ba
  * You should add additional methods to this class to meet the
  * application requirements. This class will only be generated as
  * long as it does not already exist in the output directory.
- *
  */
 class AbstractSpyProductOptionValuePriceQuery extends BaseSpyProductOptionValuePriceQuery
 {

--- a/src/Spryker/Zed/ProductOption/Persistence/Propel/AbstractSpyProductOptionValueQuery.php
+++ b/src/Spryker/Zed/ProductOption/Persistence/Propel/AbstractSpyProductOptionValueQuery.php
@@ -17,7 +17,6 @@ use Orm\Zed\ProductOption\Persistence\Base\SpyProductOptionValueQuery as BaseSpy
  * You should add additional methods to this class to meet the
  * application requirements. This class will only be generated as
  * long as it does not already exist in the output directory.
- *
  */
 class AbstractSpyProductOptionValueQuery extends BaseSpyProductOptionValueQuery
 {

--- a/src/Spryker/Zed/ProductOption/Persistence/Propel/Mapper/ProductOptionMapper.php
+++ b/src/Spryker/Zed/ProductOption/Persistence/Propel/Mapper/ProductOptionMapper.php
@@ -7,7 +7,12 @@
 
 namespace Spryker\Zed\ProductOption\Persistence\Propel\Mapper;
 
+use ArrayObject;
+use Generated\Shared\Transfer\MoneyValueTransfer;
 use Generated\Shared\Transfer\ProductAbstractOptionGroupStatusTransfer;
+use Generated\Shared\Transfer\ProductOptionGroupTransfer;
+use Generated\Shared\Transfer\ProductOptionValueTransfer;
+use Propel\Runtime\Collection\ObjectCollection;
 
 class ProductOptionMapper
 {
@@ -39,5 +44,54 @@ class ProductOptionMapper
     ): ProductAbstractOptionGroupStatusTransfer {
         return (new ProductAbstractOptionGroupStatusTransfer())
             ->fromArray($productAbstractOptionGroupStatus);
+    }
+
+    /**
+     * @param \Propel\Runtime\Collection\ObjectCollection|\Orm\Zed\ProductOption\Persistence\SpyProductOptionValue[] $productOptionValueEntities
+     *
+     * @return \Generated\Shared\Transfer\ProductOptionValueTransfer[]
+     */
+    public function mapProductOptionValueEntityCollectionToProductOptionValueTransfers(
+        ObjectCollection $productOptionValueEntities
+    ): array {
+        $productOptionValueTransfers = [];
+
+        foreach ($productOptionValueEntities as $productOptionValueEntity) {
+            $productOptionValueTransfers[] = (new ProductOptionValueTransfer())
+                ->fromArray($productOptionValueEntity->toArray(), true)
+                ->setProductOptionGroup(
+                    (new ProductOptionGroupTransfer())
+                        ->fromArray($productOptionValueEntity->getSpyProductOptionGroup()->toArray(), true)
+                )
+                ->setPrices(
+                    $this->mapProductOptionValuePriceEntitiesToMoneyValueTransfers(
+                        $productOptionValueEntity->getProductOptionValuePrices()
+                    )
+                );
+        }
+
+        return $productOptionValueTransfers;
+    }
+
+    /**
+     * @param \Propel\Runtime\Collection\ObjectCollection|\Orm\Zed\ProductOption\Persistence\SpyProductOptionValuePrice[] $productOptionValuePriceEntities
+     *
+     * @return \ArrayObject|\Generated\Shared\Transfer\MoneyValueTransfer[]
+     */
+    protected function mapProductOptionValuePriceEntitiesToMoneyValueTransfers(
+        ObjectCollection $productOptionValuePriceEntities
+    ): ArrayObject {
+        $moneyValueTransfers = new ArrayObject();
+
+        foreach ($productOptionValuePriceEntities as $productOptionValuePriceEntity) {
+            $moneyValueTransfers->append(
+                (new MoneyValueTransfer())
+                    ->fromArray($productOptionValuePriceEntity->toArray(), true)
+                    ->setGrossAmount($productOptionValuePriceEntity->getGrossPrice())
+                    ->setNetAmount($productOptionValuePriceEntity->getNetPrice())
+            );
+        }
+
+        return $moneyValueTransfers;
     }
 }

--- a/tests/SprykerTest/Client/ProductOption/OptionGroup/ProductOptionValuePriceReaderTest.php
+++ b/tests/SprykerTest/Client/ProductOption/OptionGroup/ProductOptionValuePriceReaderTest.php
@@ -18,6 +18,7 @@ use Spryker\Shared\ProductOption\ProductOptionConstants;
 
 /**
  * Auto-generated group annotations
+ *
  * @group SprykerTest
  * @group Zed
  * @group ProductOption

--- a/tests/SprykerTest/Client/ProductOption/_support/ProductOptionClientTester.php
+++ b/tests/SprykerTest/Client/ProductOption/_support/ProductOptionClientTester.php
@@ -11,6 +11,7 @@ use Codeception\Actor;
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)

--- a/tests/SprykerTest/Zed/ProductOption/Business/Calculator/ProductOptionTaxRateCalculationTest.php
+++ b/tests/SprykerTest/Zed/ProductOption/Business/Calculator/ProductOptionTaxRateCalculationTest.php
@@ -18,6 +18,7 @@ use Spryker\Zed\ProductOption\Persistence\ProductOptionQueryContainer;
 
 /**
  * Auto-generated group annotations
+ *
  * @group SprykerTest
  * @group Zed
  * @group ProductOption

--- a/tests/SprykerTest/Zed/ProductOption/Business/OptionGroup/AbstractProductOptionSaverTest.php
+++ b/tests/SprykerTest/Zed/ProductOption/Business/OptionGroup/AbstractProductOptionSaverTest.php
@@ -12,6 +12,7 @@ use Orm\Zed\ProductOption\Persistence\SpyProductOptionGroup;
 use Spryker\Zed\ProductOption\Business\Exception\AbstractProductNotFoundException;
 use Spryker\Zed\ProductOption\Business\Exception\ProductOptionGroupNotFoundException;
 use Spryker\Zed\ProductOption\Business\OptionGroup\AbstractProductOptionSaver;
+use Spryker\Zed\ProductOption\Business\OptionGroup\AbstractProductOptionSaverInterface;
 use Spryker\Zed\ProductOption\Dependency\Facade\ProductOptionToEventFacadeInterface;
 use Spryker\Zed\ProductOption\Dependency\Facade\ProductOptionToTouchFacadeInterface;
 use Spryker\Zed\ProductOption\Persistence\ProductOptionQueryContainerInterface;
@@ -19,6 +20,7 @@ use SprykerTest\Zed\ProductOption\Business\MockProvider;
 
 /**
  * Auto-generated group annotations
+ *
  * @group SprykerTest
  * @group Zed
  * @group ProductOption
@@ -101,8 +103,7 @@ class AbstractProductOptionSaverTest extends MockProvider
         ?ProductOptionQueryContainerInterface $productOptionContainerMock = null,
         ?ProductOptionToTouchFacadeInterface $touchFacadeMock = null,
         ?ProductOptionToEventFacadeInterface $eventFacadeMock = null
-    ) {
-
+    ): AbstractProductOptionSaverInterface {
         if (!$productOptionContainerMock) {
             $productOptionContainerMock = $this->createProductOptionQueryContainerMock();
         }
@@ -130,7 +131,7 @@ class AbstractProductOptionSaverTest extends MockProvider
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject|\Orm\Zed\ProductOption\Persistence\SpyProductOptionGroup
      */
-    protected function createProductOptionGroupEntityMock()
+    protected function createProductOptionGroupEntityMock(): SpyProductOptionGroup
     {
         return $this->getMockBuilder(SpyProductOptionGroup::class)
             ->setMethods(['save'])

--- a/tests/SprykerTest/Zed/ProductOption/Business/OptionGroup/ProductOptionGroupReaderTest.php
+++ b/tests/SprykerTest/Zed/ProductOption/Business/OptionGroup/ProductOptionGroupReaderTest.php
@@ -14,10 +14,12 @@ use Orm\Zed\ProductOption\Persistence\SpyProductOptionGroupQuery;
 use Propel\Runtime\Collection\ObjectCollection;
 use Spryker\Zed\ProductOption\Business\Exception\ProductOptionGroupNotFoundException;
 use Spryker\Zed\ProductOption\Business\OptionGroup\ProductOptionGroupReader;
+use Spryker\Zed\ProductOption\Persistence\ProductOptionQueryContainerInterface;
 use SprykerTest\Zed\ProductOption\Business\MockProvider;
 
 /**
  * Auto-generated group annotations
+ *
  * @group SprykerTest
  * @group Zed
  * @group ProductOption
@@ -86,7 +88,7 @@ class ProductOptionGroupReaderTest extends MockProvider
      *
      * @return \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\ProductOption\Persistence\ProductOptionQueryContainerInterface
      */
-    protected function getQueryContainerMock(?SpyProductOptionGroup $productOptionGroupEntity = null)
+    protected function getQueryContainerMock(?SpyProductOptionGroup $productOptionGroupEntity = null): ProductOptionQueryContainerInterface
     {
         $groupCollection = $this->getMockBuilder(ObjectCollection::class)->getMock();
         $groupCollection->expects($this->any())->method('getFirst')->willReturn($productOptionGroupEntity);

--- a/tests/SprykerTest/Zed/ProductOption/Business/OptionGroup/ProductOptionGroupSaverTest.php
+++ b/tests/SprykerTest/Zed/ProductOption/Business/OptionGroup/ProductOptionGroupSaverTest.php
@@ -23,6 +23,7 @@ use SprykerTest\Zed\ProductOption\Business\MockProvider;
 
 /**
  * Auto-generated group annotations
+ *
  * @group SprykerTest
  * @group Zed
  * @group ProductOption
@@ -136,8 +137,7 @@ class ProductOptionGroupSaverTest extends MockProvider
         ?TranslationSaverInterface $translationSaverMock = null,
         ?ProductOptionValueSaverInterface $productOptionValueSaverMock = null,
         ?AbstractProductOptionSaverInterface $abstractProductOptionSaver = null
-    ) {
-
+    ): ProductOptionGroupSaver {
         if (!$productOptionContainerMock) {
             $productOptionContainerMock = $this->createProductOptionQueryContainerMock();
         }
@@ -179,7 +179,7 @@ class ProductOptionGroupSaverTest extends MockProvider
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject|\Orm\Zed\ProductOption\Persistence\SpyProductOptionGroup
      */
-    protected function createProductOptionGroupEntityMock()
+    protected function createProductOptionGroupEntityMock(): SpyProductOptionGroup
     {
         return $this->getMockBuilder(SpyProductOptionGroup::class)
             ->setMethods(['save'])

--- a/tests/SprykerTest/Zed/ProductOption/Business/OptionGroup/ProductOptionOrderSaverTest.php
+++ b/tests/SprykerTest/Zed/ProductOption/Business/OptionGroup/ProductOptionOrderSaverTest.php
@@ -19,6 +19,7 @@ use SprykerTest\Zed\ProductOption\Business\MockProvider;
 
 /**
  * Auto-generated group annotations
+ *
  * @group SprykerTest
  * @group Zed
  * @group ProductOption
@@ -80,7 +81,7 @@ class ProductOptionOrderSaverTest extends MockProvider
      *
      * @return \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\ProductOption\Business\OptionGroup\ProductOptionOrderSaver
      */
-    protected function createProductOptionOrderSaver(?ProductOptionToGlossaryFacadeInterface $glossaryFacadeMock = null)
+    protected function createProductOptionOrderSaver(?ProductOptionToGlossaryFacadeInterface $glossaryFacadeMock = null): ProductOptionOrderSaver
     {
         if (!$glossaryFacadeMock) {
             $glossaryFacadeMock = $this->createGlossaryFacadeMock();
@@ -95,7 +96,7 @@ class ProductOptionOrderSaverTest extends MockProvider
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject|\Orm\Zed\Sales\Persistence\SpySalesOrderItemOption
      */
-    protected function createSalesOrderItemOptionMock()
+    protected function createSalesOrderItemOptionMock(): SpySalesOrderItemOption
     {
         return $this->getMockBuilder(SpySalesOrderItemOption::class)
             ->setMethods(['save'])

--- a/tests/SprykerTest/Zed/ProductOption/Business/OptionGroup/ProductOptionValueReaderTest.php
+++ b/tests/SprykerTest/Zed/ProductOption/Business/OptionGroup/ProductOptionValueReaderTest.php
@@ -12,11 +12,13 @@ use Orm\Zed\ProductOption\Persistence\SpyProductOptionGroup;
 use Orm\Zed\ProductOption\Persistence\SpyProductOptionValue;
 use Spryker\Zed\ProductOption\Business\Exception\ProductOptionNotFoundException;
 use Spryker\Zed\ProductOption\Business\OptionGroup\ProductOptionValuePriceReader;
+use Spryker\Zed\ProductOption\Business\OptionGroup\ProductOptionValuePriceReaderInterface;
 use Spryker\Zed\ProductOption\Business\OptionGroup\ProductOptionValueReader;
 use SprykerTest\Zed\ProductOption\Business\MockProvider;
 
 /**
  * Auto-generated group annotations
+ *
  * @group SprykerTest
  * @group Zed
  * @group ProductOption
@@ -86,7 +88,7 @@ class ProductOptionValueReaderTest extends MockProvider
      *
      * @return \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\ProductOption\Business\OptionGroup\ProductOptionValueReader
      */
-    protected function createProductOptionValueReader()
+    protected function createProductOptionValueReader(): ProductOptionValueReader
     {
         $productOptionQueryContainerMock = $this->createProductOptionQueryContainerMock();
         $productOptionValuePriceReaderMock = $this->createProductOptionValuePriceReaderMock();
@@ -105,7 +107,7 @@ class ProductOptionValueReaderTest extends MockProvider
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\ProductOption\Business\OptionGroup\ProductOptionValuePriceReaderInterface
      */
-    protected function createProductOptionValuePriceReaderMock()
+    protected function createProductOptionValuePriceReaderMock(): ProductOptionValuePriceReaderInterface
     {
         return $this->getMockBuilder(ProductOptionValuePriceReader::class)
             ->disableOriginalConstructor()
@@ -118,7 +120,7 @@ class ProductOptionValueReaderTest extends MockProvider
      *
      * @return \PHPUnit\Framework\MockObject\MockObject|\Orm\Zed\ProductOption\Persistence\SpyProductOptionValue
      */
-    protected function createProductOptionValueEntityMock()
+    protected function createProductOptionValueEntityMock(): SpyProductOptionValue
     {
         return $this->getMockBuilder(SpyProductOptionValue::class)
             ->setMethods(['save', 'getSpyProductOptionGroup'])

--- a/tests/SprykerTest/Zed/ProductOption/Business/OptionGroup/ProductOptionValueSaverTest.php
+++ b/tests/SprykerTest/Zed/ProductOption/Business/OptionGroup/ProductOptionValueSaverTest.php
@@ -12,10 +12,12 @@ use Generated\Shared\Transfer\MoneyValueTransfer;
 use Generated\Shared\Transfer\ProductOptionValueTransfer;
 use Orm\Zed\ProductOption\Persistence\SpyProductOptionValue;
 use Spryker\Zed\ProductOption\Business\OptionGroup\ProductOptionValueSaver;
+use Spryker\Zed\ProductOption\Business\OptionGroup\ProductOptionValueSaverInterface;
 use SprykerTest\Zed\ProductOption\Business\MockProvider;
 
 /**
  * Auto-generated group annotations
+ *
  * @group SprykerTest
  * @group Zed
  * @group ProductOption
@@ -62,7 +64,7 @@ class ProductOptionValueSaverTest extends MockProvider
      *
      * @return \PHPUnit\Framework\MockObject\MockObject|\Orm\Zed\ProductOption\Persistence\SpyProductOptionValue
      */
-    protected function createProductOptionValueEntityMock()
+    protected function createProductOptionValueEntityMock(): SpyProductOptionValue
     {
         return $this->getMockBuilder(SpyProductOptionValue::class)
             ->setMethods(['save'])
@@ -74,7 +76,7 @@ class ProductOptionValueSaverTest extends MockProvider
      *
      * @return \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\ProductOption\Business\OptionGroup\ProductOptionValueSaverInterface
      */
-    protected function createProductOptionValueSaver()
+    protected function createProductOptionValueSaver(): ProductOptionValueSaverInterface
     {
         return $this->getMockBuilder(ProductOptionValueSaver::class)
             ->setConstructorArgs([

--- a/tests/SprykerTest/Zed/ProductOption/Business/OptionGroup/TranslationSaverTest.php
+++ b/tests/SprykerTest/Zed/ProductOption/Business/OptionGroup/TranslationSaverTest.php
@@ -17,6 +17,7 @@ use SprykerTest\Zed\ProductOption\Business\MockProvider;
 
 /**
  * Auto-generated group annotations
+ *
  * @group SprykerTest
  * @group Zed
  * @group ProductOption

--- a/tests/SprykerTest/Zed/ProductOption/Business/ProductOptionFacade/GetProductOptionsTest.php
+++ b/tests/SprykerTest/Zed/ProductOption/Business/ProductOptionFacade/GetProductOptionsTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerTest\Zed\ProductOption\Business\ProductOptionFacade;
+
+use Codeception\Test\Unit;
+use Generated\Shared\Transfer\ProductOptionCriteriaTransfer;
+
+/**
+ * Auto-generated group annotations
+ *
+ * @group SprykerTest
+ * @group Zed
+ * @group ProductOption
+ * @group Business
+ * @group ProductOptionFacade
+ * @group GetProductOptionsTest
+ * Add your own group annotations below this line
+ */
+class GetProductOptionsTest extends Unit
+{
+    /**
+     * @var \SprykerTest\Zed\ProductOption\ProductOptionBusinessTester
+     */
+    protected $tester;
+
+    /**
+     * @var \Generated\Shared\Transfer\ProductOptionGroupTransfer
+     */
+    protected $productOptionGroupTransfer;
+
+    /**
+     * @var \Generated\Shared\Transfer\ProductOptionGroupTransfer
+     */
+    protected $anotherProductOptionGroupTransfer;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->productOptionGroupTransfer = $this->tester->haveProductOptionGroupWithValues();
+        $this->anotherProductOptionGroupTransfer = $this->tester->haveProductOptionGroupWithValues();
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetProductOptionsWillRetrieveExistingOptionBySku(): void
+    {
+        // Arrange
+        $productOptionCriteriaTransfer = (new ProductOptionCriteriaTransfer())
+            ->setProductOptionSkus(
+                [
+                    $this->productOptionGroupTransfer->getProductOptionValues()->offsetGet(0)->getSku(),
+                    $this->anotherProductOptionGroupTransfer->getProductOptionValues()->offsetGet(0)->getSku(),
+                ]
+            );
+
+        // Act
+        $productOptionCollectionTransfer = $this->tester
+            ->getFacade()
+            ->get($productOptionCriteriaTransfer);
+
+        // Assert
+        $this->assertNotEmpty($productOptionCollectionTransfer->getProductOptions());
+        $this->assertCount(2, $productOptionCollectionTransfer->getProductOptions());
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetProductOptionsWillRetrieveExistingOptionById(): void
+    {
+        // Arrange
+        $productOptionCriteriaTransfer = (new ProductOptionCriteriaTransfer())
+            ->setProductOptionIds(
+                [
+                    $this->productOptionGroupTransfer->getProductOptionValues()->offsetGet(0)->getIdProductOptionValue(),
+                    $this->anotherProductOptionGroupTransfer->getProductOptionValues()->offsetGet(0)->getIdProductOptionValue(),
+                ]
+            );
+
+        // Act
+        $productOptionCollectionTransfer = $this->tester
+            ->getFacade()
+            ->get($productOptionCriteriaTransfer);
+
+        // Assert
+        $this->assertNotEmpty($productOptionCollectionTransfer->getProductOptions());
+        $this->assertCount(2, $productOptionCollectionTransfer->getProductOptions());
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetProductOptionsWillRetrieveExistingOptionByIdAndSku(): void
+    {
+        // Arrange
+        $productOptionCriteriaTransfer = (new ProductOptionCriteriaTransfer())
+            ->setProductOptionIds(
+                [
+                    $this->productOptionGroupTransfer->getProductOptionValues()->offsetGet(0)->getIdProductOptionValue(),
+                    $this->anotherProductOptionGroupTransfer->getProductOptionValues()->offsetGet(0)->getIdProductOptionValue(),
+                ]
+            )
+            ->setProductOptionSkus(
+                [
+                    $this->productOptionGroupTransfer->getProductOptionValues()->offsetGet(0)->getSku(),
+                    $this->anotherProductOptionGroupTransfer->getProductOptionValues()->offsetGet(0)->getSku(),
+                ]
+            );
+
+        // Act
+        $productOptionCollectionTransfer = $this->tester
+            ->getFacade()
+            ->get($productOptionCriteriaTransfer);
+
+        // Assert
+        $this->assertNotEmpty($productOptionCollectionTransfer->getProductOptions());
+        $this->assertCount(2, $productOptionCollectionTransfer->getProductOptions());
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetProductOptionsWillNotFindOptionByIdAndSku(): void
+    {
+        // Arrange
+        $productOptionCriteriaTransfer = (new ProductOptionCriteriaTransfer())
+            ->setProductOptionIds(
+                [
+                    99999,
+                    $this->productOptionGroupTransfer->getProductOptionValues()->offsetGet(0)->getIdProductOptionValue(),
+                ]
+            )
+            ->setProductOptionSkus(
+                [
+                    '99999',
+                    $this->productOptionGroupTransfer->getProductOptionValues()->offsetGet(0)->getSku(),
+                ]
+            );
+
+        // Act
+        $productOptionCollectionTransfer = $this->tester
+            ->getFacade()
+            ->get($productOptionCriteriaTransfer);
+
+        // Assert
+        $this->assertNotEmpty($productOptionCollectionTransfer->getProductOptions());
+        $this->assertCount(1, $productOptionCollectionTransfer->getProductOptions());
+    }
+}

--- a/tests/SprykerTest/Zed/ProductOption/Business/ProductOptionFacadeTest.php
+++ b/tests/SprykerTest/Zed/ProductOption/Business/ProductOptionFacadeTest.php
@@ -28,6 +28,7 @@ use SprykerTest\Shared\ProductOption\Helper\ProductOptionGroupDataHelper;
 
 /**
  * Auto-generated group annotations
+ *
  * @group SprykerTest
  * @group Zed
  * @group ProductOption

--- a/tests/SprykerTest/Zed/ProductOption/Communication/Controller/ProductOptionListCest.php
+++ b/tests/SprykerTest/Zed/ProductOption/Communication/Controller/ProductOptionListCest.php
@@ -12,6 +12,7 @@ use SprykerTest\Zed\ProductOption\ProductOptionCommunicationTester;
 
 /**
  * Auto-generated group annotations
+ *
  * @group SprykerTest
  * @group Zed
  * @group ProductOption

--- a/tests/SprykerTest/Zed/ProductOption/Communication/Controller/ProductOptionViewCest.php
+++ b/tests/SprykerTest/Zed/ProductOption/Communication/Controller/ProductOptionViewCest.php
@@ -12,6 +12,7 @@ use SprykerTest\Zed\ProductOption\ProductOptionCommunicationTester;
 
 /**
  * Auto-generated group annotations
+ *
  * @group SprykerTest
  * @group Zed
  * @group ProductOption

--- a/tests/SprykerTest/Zed/ProductOption/Persistence/ProductOptionQueryContainerTest.php
+++ b/tests/SprykerTest/Zed/ProductOption/Persistence/ProductOptionQueryContainerTest.php
@@ -16,6 +16,7 @@ use Spryker\Zed\ProductOption\Persistence\ProductOptionQueryContainer;
 
 /**
  * Auto-generated group annotations
+ *
  * @group SprykerTest
  * @group Zed
  * @group ProductOption

--- a/tests/SprykerTest/Zed/ProductOption/Presentation/ProductOptionCreateCest.php
+++ b/tests/SprykerTest/Zed/ProductOption/Presentation/ProductOptionCreateCest.php
@@ -12,6 +12,7 @@ use SprykerTest\Zed\ProductOption\ProductOptionPresentationTester;
 
 /**
  * Auto-generated group annotations
+ *
  * @group SprykerTest
  * @group Zed
  * @group ProductOption

--- a/tests/SprykerTest/Zed/ProductOption/Presentation/ProductOptionEditCest.php
+++ b/tests/SprykerTest/Zed/ProductOption/Presentation/ProductOptionEditCest.php
@@ -13,6 +13,7 @@ use SprykerTest\Zed\ProductOption\ProductOptionPresentationTester;
 
 /**
  * Auto-generated group annotations
+ *
  * @group SprykerTest
  * @group Zed
  * @group ProductOption

--- a/tests/SprykerTest/Zed/ProductOption/_support/ProductOptionBusinessTester.php
+++ b/tests/SprykerTest/Zed/ProductOption/_support/ProductOptionBusinessTester.php
@@ -25,6 +25,7 @@ use Spryker\Zed\ProductOption\Dependency\Facade\ProductOptionToStoreFacadeBridge
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)
@@ -34,17 +35,13 @@ use Spryker\Zed\ProductOption\Dependency\Facade\ProductOptionToStoreFacadeBridge
  * @method void am($role)
  * @method void lookForwardTo($achieveValue)
  * @method void comment($description)
- * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = null)
  *
  * @SuppressWarnings(PHPMD)
  */
 class ProductOptionBusinessTester extends Actor
 {
     use _generated\ProductOptionBusinessTesterActions;
-
-   /**
-    * Define custom actions here
-    */
 
     /**
      * @param \Generated\Shared\Transfer\ProductOptionValueTransfer $productOptionValueTransfer

--- a/tests/SprykerTest/Zed/ProductOption/_support/ProductOptionCommunicationTester.php
+++ b/tests/SprykerTest/Zed/ProductOption/_support/ProductOptionCommunicationTester.php
@@ -11,6 +11,7 @@ use Codeception\Actor;
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)

--- a/tests/SprykerTest/Zed/ProductOption/_support/ProductOptionPersistenceTester.php
+++ b/tests/SprykerTest/Zed/ProductOption/_support/ProductOptionPersistenceTester.php
@@ -11,6 +11,7 @@ use Codeception\Actor;
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)

--- a/tests/SprykerTest/Zed/ProductOption/_support/ProductOptionPresentationTester.php
+++ b/tests/SprykerTest/Zed/ProductOption/_support/ProductOptionPresentationTester.php
@@ -17,6 +17,7 @@ use Generated\Shared\Transfer\ProductOptionValueTransfer;
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)


### PR DESCRIPTION
Branch: backport/6.12.0

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   ProductOption               | minor                 |                       |

#### Release Notes

Parent Epic
- https://spryker.atlassian.net/browse/GLUE-10992

Parent PR
- https://github.com/spryker/spryker/pull/7873

-----------------------------------------

#### Module ProductOption

##### Change log

Improvements

- Added a new facade method `ProductOptionFacade::get()`.
- Added a new business logic in `ProductOptionReader` that is using `ProductOptionFacade::get()`
- Added a new repository method `ProductOptionRepository::get()`
- Updated new properties `productOptionSkus` and `storeIds` to `ProductOptionCriteriaTransfer`
- Updated a new property `productOptionGroup` to `ProductOptionValue`
